### PR TITLE
Increase Spack-friendliness

### DIFF
--- a/fwq/Makefile
+++ b/fwq/Makefile
@@ -9,9 +9,9 @@
 #--> compatible processor. If not, write your own!  
 #CFLAGS =-I../common -O1 -march=native -mtune=native -m64 -static flags
 
-CC    = gcc
-CXX   = g++
-MPICC = mpicc
+CC    ?= gcc
+CXX   ?= g++
+MPICC ?= mpicc
 
 ARCH = $(shell uname -m)
 

--- a/scripts/fwq-stats.py
+++ b/scripts/fwq-stats.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 '''
 Edgar A. Leon
 Lawrence Livermore National Laboratory


### PR DESCRIPTION
Hello Edgar,

I changed the Makefile to allow Spack to easily override the various compiler arguments and made the fwq-stats.py script more of a standalone executable so that Spack can "install" it to the `bin` directory.
Please let me know what you think.

Thanks,
Nate